### PR TITLE
Add python-gflags to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pystache>=0.5.4
 nose
 requests
+python-gflags


### PR DESCRIPTION
Reminded by https://github.com/tonyyang-svail, the following demo requires the package python-gflags.

https://github.com/multiparty/conclave/blob/4afa84f40e860b19f2655cb1eee4c950bc27f11c/benchmarks/ssn/data_gen.py#L5